### PR TITLE
Use `syntax/lang` to abstract over language creation plumbing

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 
 (define deps
   '("base"
-    "git://github.com/jackfirth/racket-syntax-lang"
+    "syntax-lang"
     ))
 
 (define build-deps

--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 
 (define deps
   '("base"
-    "syntax-lang"
+    "syntax-macro-lang"
     ))
 
 (define build-deps

--- a/info.rkt
+++ b/info.rkt
@@ -4,6 +4,7 @@
 
 (define deps
   '("base"
+    "git://github.com/jackfirth/racket-syntax-lang"
     ))
 
 (define build-deps

--- a/reprovide/lang/reader.rkt
+++ b/reprovide/lang/reader.rkt
@@ -1,1 +1,0 @@
-#lang s-exp syntax/module-reader reprovide

--- a/reprovide/main.rkt
+++ b/reprovide/main.rkt
@@ -1,7 +1,4 @@
-#lang racket/base
-
-(require syntax/lang)
-
+#lang s-exp syntax/macro-lang reprovide reprovide
 
 (provide #%datum
          submod
@@ -22,5 +19,3 @@
          )
 
 (require "reprovide.rkt")
-
-(define-lang-syntax reprovide reprovide)

--- a/reprovide/main.rkt
+++ b/reprovide/main.rkt
@@ -1,7 +1,9 @@
 #lang racket/base
 
-(provide (rename-out [-#%module-begin #%module-begin])
-         #%datum
+(require syntax/lang)
+
+
+(provide #%datum
          submod
          lib
          file
@@ -21,5 +23,4 @@
 
 (require "reprovide.rkt")
 
-(define-syntax-rule (-#%module-begin require-spec ...)
-  (#%module-begin (reprovide require-spec ...)))
+(define-lang-syntax reprovide reprovide)


### PR DESCRIPTION
This PR uses a new library I made, [`syntax-lang`](https://github.com/jackfirth/racket-syntax-lang), to simplify the implementation of the language. `define-lang-syntax` uses reader submodules and `syntax/module-reader` to create a new `#lang` from a given macro, similar to `syntax/module-reader`. Reader submodules let it keep all the code for reading and expanding in the same file. For details of how that works, see [the submodules blog post](http://blog.racket-lang.org/2012/06/submodules.html). (I couldn't find anything in the docs about reader submodules, as far as I know they're only mentioned in that blog post.)

This is mostly a test of the library, let me know what you think.
