### PR TITLE
depend on lang-file-lib, not lang-file

### DIFF
--- a/reprovide-lang-lib/info.rkt
+++ b/reprovide-lang-lib/info.rkt
@@ -4,6 +4,6 @@
 
 (define deps
   '("base"
-    "lang-file"
+    "lang-file-lib"
     "syntax-macro-lang"
     ))


### PR DESCRIPTION
So that `reprovide-lang-lib` can be installed without depending transitively on `racket-doc`, for #11 